### PR TITLE
Restore PR #20 as the build error is now fixed

### DIFF
--- a/.github/workflows/stargate.yml
+++ b/.github/workflows/stargate.yml
@@ -1,0 +1,34 @@
+name: Stargate
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+
+  deploy:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install dependencies
+      run: ./scripts/debian_deps.sh
+    - name: Update git submodules
+      run: git submodule init && git submodule update
+
+    - name: Build
+      run: ./scripts/deb.py && ./scripts/rpm.py --nodeps
+
+    - name: DEB Upload
+      uses: actions/upload-artifact@v2.2.4
+      with:
+        name: DEB package
+        path: ./src/*.deb
+
+    - name: RPM Upload
+      uses: actions/upload-artifact@v2.2.4
+      with:
+        name: RPM package
+        path: ./*.rpm

--- a/.github/workflows/stargate.yml
+++ b/.github/workflows/stargate.yml
@@ -1,10 +1,7 @@
 name: Stargate
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+  workflow_dispatch
 
 jobs:
 

--- a/scripts/deb.py
+++ b/scripts/deb.py
@@ -145,24 +145,13 @@ postinst_path = os.path.join(
 #     f.write(postinst)
 # os.chmod(postinst_path, 0o755)
 retcode = os.system(f"dpkg-deb --build --root-owner-group {root}")
-assert not retcode, retcode
-try:
-    import distro
-    distro_name = distro.name().split()[0].lower()
-    distro_version = distro.version().lower().replace(' ', '-')
-    package = (
-        f"{major_version}-{minor_version}-"
-        f"{distro_name}-{distro_version}-{arch}.deb"
-    )
-except ImportError:
-    package = f"{major_version}-{minor_version}-{arch}.deb"
+assert not retcode, f"dpkg-deb exited with status retcode"
 
-os.rename(
-    os.path.join(CWD, "tmp.deb"),
-    os.path.join(CWD, package),
-)
-package_path = os.path.join(CWD, package)
-print(f"Created {package_path}")
+retcode = os.system(f"dpkg-name {os.path.join(CWD, 'tmp.deb')}")
+assert not retcode, f"dpkg-name exited with status retcode"
+
+print("Created package")
+os.system(f"ls -l {CWD}/*.deb")
 
 if args.install:
     retcode = os.system(f'sudo apt install -y --reinstall ./{package}')

--- a/scripts/debian_deps.sh
+++ b/scripts/debian_deps.sh
@@ -30,6 +30,7 @@ sudo apt-get install -y \
     python3-pip \
     python3-pyqt5 \
     python3-pyqt5.qtsvg \
+    python3-setuptools \
     rubberband-cli \
     squashfs-tools \
     vorbis-tools

--- a/scripts/rpm.py
+++ b/scripts/rpm.py
@@ -34,6 +34,12 @@ def parse_args():
         default=None,
         help='Use non-default PLAT_FLAGS to compile',
     )
+    parser.add_argument(
+        '--nodeps',
+        action='store_true',
+        dest='nodeps',
+        help="(rpmbuild) Do not verify build dependencies",
+    )
     return parser.parse_args()
 
 args = parse_args()
@@ -68,16 +74,15 @@ PACKAGE_NAME = "{}-{}".format(
     MAJOR_VERSION, global_version_fedora)
 
 global_home = os.path.expanduser("~")
-rpm_build_path = os.path.join(
-    global_home,
-    'rpmbuild',
-    "BUILD",
-    MAJOR_VERSION,
-)
-os.system(f'rm -rf {rpm_build_path}*')
+rpmbuild_path = os.path.join(global_home, 'rpmbuild')
+os.system(f'rm -rf {os.path.join(rpmbuild_path, "BUILD", MAJOR_VERSION)}*')
 
-if not os.path.isdir("{}/rpmbuild".format(global_home)):
-    os.system("rpmdev-setuptree")
+# If rpmbuild_path doesn't exist, create it manually. This is equivalent
+# to what rpmdev-setuptree does on Fedora/RHEL, but works on any distro.
+if not os.path.isdir(rpmbuild_path):
+    os.mkdir(rpmbuild_path)
+    for dirname in ['BUILD', 'RPMS', 'SOURCES', 'SPECS', 'SRPMS']:
+        os.mkdir(os.path.join(rpmbuild_path, dirname))
 
 SPEC_DIR = "{}/rpmbuild/SPECS/".format(global_home)
 SOURCE_DIR = "{}/rpmbuild/SOURCES/".format(global_home)
@@ -186,7 +191,8 @@ if args.install:
     os.system('rm -f {}-*'.format(MAJOR_VERSION))
 
 os.chdir(SPEC_DIR)
-f_rpm_result = os.system("rpmbuild -ba {}".format(global_spec_file))
+nodeps = '--nodeps' if args.nodeps else ''
+f_rpm_result = os.system(f"rpmbuild -ba {nodeps} {global_spec_file}")
 
 if f_rpm_result:
     print("Error:  rpmbuild returned {}".format(f_rpm_result))


### PR DESCRIPTION
The commit 85c3f51b74ef1c8f7c91fd7b5b1fade911e770b8 ("Allow building and installing without any vendored dependencies") resulted in Makefile's `py_vendor` target failing when one of `pip install` exited with an error. However, `pip install` was already returning errors. The target `all` depended on `py_vendor`, and this ended up failing the build.

The commit c93792e3cefe53507a387e0f6102e79676e568e3 ("Makefile: More modular targets") removed the `py_vendor` as build dependency. Now the automated build is working again.