### PR TITLE
fix: AssertionError in assert sbsms_util

### DIFF
--- a/src/sglib/lib/util.py
+++ b/src/sglib/lib/util.py
@@ -187,10 +187,10 @@ elif IS_LINUX:
         os.path.dirname(__file__),
         '..',
         '..',
-        'vendor',
-        'sbsms',
-        'cli',
-        'sbsms',
+        '..',
+        '..',
+        '..',
+        'bin',
     )
     if not os.path.exists(sbsms_util):
         sbsms_util = which(f"{MAJOR_VERSION}-sbsms")


### PR DESCRIPTION
install_sbsms make target only copies the file vendor/sbsms/cli/sbsms to
$PREFIX/bin/, not the directories, so when running the stargate binary it won't find
sbsms binary in ../../vendor/sbsms/cli/sbsms.

```
[2021-11-17 17:44:22,271] ERROR /nix/store/j3sxg0rqwrjbm3vfnlz1rlz9x8yclkp7-stargate-21.11.5/usr/share/stargate/stargate/sglib/log.py: 90 - Traceback (most recent call last):

  File "/nix/store/j3sxg0rqwrjbm3vfnlz1rlz9x8yclkp7-stargate-21.11.5/usr/bin/.stargate-wrapped", line 170, in <module>
    main()

  File "/nix/store/j3sxg0rqwrjbm3vfnlz1rlz9x8yclkp7-stargate-21.11.5/usr/bin/.stargate-wrapped", line 167, in main
    start_stargate()

  File "/nix/store/j3sxg0rqwrjbm3vfnlz1rlz9x8yclkp7-stargate-21.11.5/usr/bin/.stargate-wrapped", line 95, in start_stargate
    app, scaler = _setup()

  File "/nix/store/j3sxg0rqwrjbm3vfnlz1rlz9x8yclkp7-stargate-21.11.5/usr/bin/.stargate-wrapped", line 75, in _setup
    from sgui.util import setup_theme

  File "/nix/store/j3sxg0rqwrjbm3vfnlz1rlz9x8yclkp7-stargate-21.11.5/usr/share/stargate/stargate/sgui/util.py", line 5, in <module>
    from sglib.lib.translate import _

  File "/nix/store/j3sxg0rqwrjbm3vfnlz1rlz9x8yclkp7-stargate-21.11.5/usr/share/stargate/stargate/sglib/lib/translate.py", line 17, in <module>
    from sglib.lib.util import SHARE_DIR

  File "/nix/store/j3sxg0rqwrjbm3vfnlz1rlz9x8yclkp7-stargate-21.11.5/usr/share/stargate/stargate/sglib/lib/util.py", line 200, in <module>
    assert sbsms_util

AssertionError
```